### PR TITLE
Add semantic analysis for procurement scanning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libxml2-dev \
     libxslt1-dev \
     libffi-dev \
+    libopenblas-dev \
+    libgomp1 \
     tzdata \
     ca-certificates \
  && rm -rf /var/lib/apt/lists/*
@@ -20,6 +22,7 @@ RUN pip install --no-cache-dir poetry \
  && poetry install --no-interaction --no-ansi --only main --no-root
 
 COPY src/ /app/src/
+COPY scripts/ /app/scripts/
 
 RUN useradd -ms /bin/bash appuser \
     && mkdir -p /data \

--- a/README.md
+++ b/README.md
@@ -90,13 +90,25 @@
 
 ## Локальный запуск (без Docker)
 
-1. Установите зависимости через Poetry:
+1. Создайте изолированное виртуальное окружение (пример для стандартного `venv`):
 
    ```bash
-   poetry install --only main
+   python -m venv .venv
    ```
 
-2. Запустите приложение:
+2. Активируйте окружение:
+
+   ```bash
+   source .venv/bin/activate  # Windows: .venv\Scripts\activate
+   ```
+
+3. Установите зависимости проекта (Poetry ставит их в активированное окружение):
+
+   ```bash
+   poetry install --no-root --only main
+   ```
+
+4. Запустите приложение, находясь в активном окружении:
 
    ```bash
    python -m src.app

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 
 - Периодический опрос первых N страниц каталога (листинг).
 - Детальный разбор страниц закупок и фильтрация по ключевым словам (уведомления только после детразбора).
+- Семантический анализ текста закупок: поиск по смыслу с управляемым порогом сходства.
 - Глобальные (единые) настройки: ключевые слова, интервал, число страниц.
 - Уведомления с названием, ссылкой и номером закупки. Дедупликация уведомлений.
 
@@ -26,6 +27,12 @@
    DETAIL_BACKOFF_BASE_SECONDS=60
    DETAIL_BACKOFF_FACTOR=2.0
    DETAIL_BACKOFF_MAX_SECONDS=3600
+   SEMANTIC_MODEL=BAAI/bge-m3
+   SEMANTIC_THRESHOLD=0.7
+   SEMANTIC_USE_XNLI=false
+   SEMANTIC_XNLI_MODEL=MoritzLaurer/mDeBERTa-v3-base-xnli
+   SEMANTIC_XNLI_THRESHOLD=0.5
+   SEMANTIC_MODELS_DIR=./models
    GZ_LIST_ITEM=.tenders-list .tender-card
    GZ_TITLE=.tender-card__title
    GZ_LINK=.tender-card__title a
@@ -57,11 +64,29 @@
    - `DETAIL_BACKOFF_FACTOR` — множитель экспоненты (2.0 означает удвоение задержки на каждый повтор).
    - `DETAIL_BACKOFF_MAX_SECONDS` — верхняя граница задержки.
 
+   Параметры семантического анализа:
+   - `SEMANTIC_MODEL` — имя sentence-transformers модели (по умолчанию `BAAI/bge-m3`).
+   - `SEMANTIC_THRESHOLD` — порог косинусного сходства (0.0–1.0).
+   - `SEMANTIC_USE_XNLI` — если `true`, дополнительно загружать zero-shot классификатор.
+   - `SEMANTIC_XNLI_MODEL` и `SEMANTIC_XNLI_THRESHOLD` — модель и порог для zero-shot оценки.
+   - `SEMANTIC_MODELS_DIR` — директория с локально скачанными моделями (по умолчанию `./models`).
+   - `SEMANTIC_DEVICE` — устройство для инференса (`cpu`, `cuda`, `auto`).
+
 ## Авторизация
 
 - Авторизация обязательна. Выполните `/login <логин> <пароль>`.
 - Авторизованный чат сохраняется между перезапусками бота.
 - Уведомления отправляются только в авторизованный чат.
+
+## Семантический поиск
+
+- Настройте фразы для поиска по смыслу командами `/squeries`, `/add_squery`, `/del_squery`, `/clear_squeries`.
+- Порог сходства изменяется командой `/set_sthreshold <0.0-1.0>` и хранится в базе.
+- Перед запуском скачайте модели в директорию `SEMANTIC_MODELS_DIR`, например:
+
+  ```bash
+  python scripts/download_models.py --models-dir ./models
+  ```
 
 ## Локальный запуск (без Docker)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,8 @@ lxml = "^5.3"
 python-dotenv = "^1.0"
 orjson = "^3.10"
 aiosqlite = "^0.20"
+numpy = "^1.26"
+sentence-transformers = ">=3.0,<4.0"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.2"

--- a/scripts/download_models.py
+++ b/scripts/download_models.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import logging
+from pathlib import Path
+
+from huggingface_hub import snapshot_download
+
+LOGGER = logging.getLogger(__name__)
+
+
+def _download_model(repo_id: str, target_dir: Path) -> Path:
+    target_dir.mkdir(parents=True, exist_ok=True)
+    local_dir = target_dir / repo_id
+    if local_dir.exists() and any(local_dir.iterdir()):
+        LOGGER.info("Model %s already present at %s", repo_id, local_dir)
+        return local_dir
+    LOGGER.info("Downloading %s to %s", repo_id, local_dir)
+    snapshot_download(repo_id=repo_id, local_dir=str(local_dir), local_dir_use_symlinks=False)
+    return local_dir
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Download semantic models for goszakupki-bot")
+    parser.add_argument("--models-dir", default="models", help="Directory to store downloaded models")
+    parser.add_argument(
+        "--embedding-model",
+        default="BAAI/bge-m3",
+        help="Sentence embedding model to download",
+    )
+    parser.add_argument(
+        "--xnli-model",
+        default="MoritzLaurer/mDeBERTa-v3-base-xnli",
+        help="Zero-shot classification model (if semantic XNLI enabled)",
+    )
+    parser.add_argument("--skip-xnli", action="store_true", help="Skip downloading the XNLI classifier")
+    args = parser.parse_args()
+
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s:%(name)s:%(message)s")
+    models_dir = Path(args.models_dir).resolve()
+    embedding_dir = _download_model(args.embedding_model, models_dir)
+    LOGGER.info("Embedding model ready at %s", embedding_dir)
+    if not args.skip_xnli and args.xnli_model:
+        xnli_dir = _download_model(args.xnli_model, models_dir)
+        LOGGER.info("XNLI model ready at %s", xnli_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/app.py
+++ b/src/app.py
@@ -34,6 +34,7 @@ async def main() -> None:
         config.provider,
         config.auth,
         container.auth_state,
+        config.semantic,
     )
     dispatcher: Dispatcher = container.dispatcher
     # Глобальная проверка авторизации

--- a/src/db/models.py
+++ b/src/db/models.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from datetime import datetime
 
-from sqlalchemy import Boolean, Column, DateTime, Integer, String, Text, UniqueConstraint
+from sqlalchemy import Boolean, Column, DateTime, Float, Integer, String, Text, UniqueConstraint
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
 
 
@@ -18,6 +18,8 @@ class AppSettings(Base):
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
     keywords: Mapped[str] = mapped_column(Text, default="", nullable=False)
+    semantic_queries: Mapped[str] = mapped_column(Text, default="", nullable=False)
+    semantic_threshold: Mapped[float] = mapped_column(Float, default=0.7, nullable=False)
     interval_seconds: Mapped[int] = mapped_column(Integer, nullable=False)
     pages: Mapped[int] = mapped_column(Integer, nullable=False)
     enabled: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)

--- a/src/di.py
+++ b/src/di.py
@@ -13,6 +13,7 @@ from .monitor.detail_scheduler import DetailScanScheduler
 from .monitor.service import MonitorService
 from .provider.base import SourceProvider
 from .provider.goszakupki_http import GoszakupkiHttpProvider
+from .semantic import SemanticAnalyzer
 from .tg.bot import create_bot, create_dispatcher
 from .tg.auth_state import AuthState
 
@@ -29,6 +30,13 @@ class Container:
         self.dispatcher: Dispatcher = create_dispatcher()
         self.provider: SourceProvider = self._create_provider()
         self.auth_state = AuthState(login=config.auth.login or "", password=config.auth.password or "", repo=self.repository)
+        self.semantic_analyzer = SemanticAnalyzer(
+            config.semantic.model,
+            models_path=config.semantic.models_dir,
+            device=config.semantic.device,
+            zero_shot_model=config.semantic.zero_shot_model if config.semantic.use_xnli else None,
+            zero_shot_threshold=config.semantic.zero_shot_threshold,
+        )
         self.monitor_service = MonitorService(
             provider=self.provider,
             repository=self.repository,
@@ -48,6 +56,8 @@ class Container:
             bot=self.bot,
             provider_config=config.provider,
             auth_state=self.auth_state,
+            semantic_analyzer=self.semantic_analyzer,
+            semantic_config=config.semantic,
         )
         self.detail_scheduler = DetailScanScheduler(
             service=self.detail_service,

--- a/src/semantic/__init__.py
+++ b/src/semantic/__init__.py
@@ -1,0 +1,179 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+import threading
+from typing import Callable, Sequence
+
+import numpy as np
+
+try:  # pragma: no cover - import guard for optional dependency
+    from sentence_transformers import SentenceTransformer
+except ImportError:  # pragma: no cover - optional dependency for runtime, tests may stub it
+    class SentenceTransformer:  # type: ignore[no-redef]
+        def __init__(self, *_, **__):
+            raise ImportError(
+                "sentence-transformers is required for SemanticAnalyzer. Install with 'pip install sentence-transformers'."
+            )
+
+        def encode(self, *_args, **_kwargs):
+            raise RuntimeError("sentence-transformers is not installed")
+
+_MODEL_CACHE: dict[str, SentenceTransformer] = {}
+_MODEL_LOCK = threading.Lock()
+_ZERO_SHOT_CACHE: dict[str, object] = {}
+
+
+@dataclass(slots=True)
+class _MatchDetails:
+    key: tuple[str, tuple[str, ...]]
+    query: str | None
+    score: float
+
+
+class SemanticAnalyzer:
+    """Wrapper around SentenceTransformer with simple caching and cosine scoring."""
+
+    def __init__(
+        self,
+        model_name: str,
+        *,
+        models_path: str | Path | None = None,
+        device: str | None = None,
+        zero_shot_model: str | None = None,
+        zero_shot_labels: Sequence[str] | None = None,
+        zero_shot_threshold: float = 0.5,
+        model_loader: Callable[[str, str | None], SentenceTransformer] | None = None,
+    ) -> None:
+        self._models_path = Path(models_path) if models_path else None
+        self._model_name = model_name
+        self._device = device
+        self._zero_shot_model = zero_shot_model
+        self._zero_shot_threshold = float(zero_shot_threshold)
+        self._zero_shot_labels = tuple(zero_shot_labels or ("procurement of equipment", "other"))
+        self._query_cache: dict[str, np.ndarray] = {}
+        self._details_lock = threading.Lock()
+        self._last_details: _MatchDetails | None = None
+        self._model_loader = model_loader or self._load_model_default
+        self._model = self._get_or_load_model(self._model_name)
+
+    # --- Public API -----------------------------------------------------
+
+    def encode(self, text: str) -> np.ndarray:
+        """Return a normalized embedding for *text*."""
+
+        cleaned = (text or "").strip()
+        if not cleaned:
+            return np.zeros(1, dtype=np.float32)
+        embedding = self._model.encode(
+            cleaned,
+            device=self._device,
+            convert_to_numpy=True,
+            normalize_embeddings=False,
+        )
+        vector = np.array(embedding, dtype=np.float32).ravel()
+        norm = float(np.linalg.norm(vector))
+        if norm == 0.0:
+            return np.zeros_like(vector)
+        return vector / norm
+
+    def is_relevant(self, text: str, queries: Sequence[str], threshold: float) -> tuple[bool, float]:
+        normalized_queries = tuple(q.strip() for q in queries if q and q.strip())
+        best_query, score = self._score(text, normalized_queries)
+        with self._details_lock:
+            self._last_details = _MatchDetails(key=(text, normalized_queries), query=best_query, score=score)
+        return (score >= float(threshold), score)
+
+    def explain_last_match(self, text: str, queries: Sequence[str]) -> tuple[str | None, float] | None:
+        normalized_queries = tuple(q.strip() for q in queries if q and q.strip())
+        key = (text, normalized_queries)
+        with self._details_lock:
+            details = self._last_details
+        if details and details.key == key:
+            return details.query, details.score
+        return None
+
+    def most_similar(self, text: str, queries: Sequence[str]) -> tuple[str | None, float]:
+        normalized_queries = tuple(q.strip() for q in queries if q and q.strip())
+        return self._score(text, normalized_queries)
+
+    def is_procurement_fact(self, text: str) -> tuple[bool, float]:
+        if not self._zero_shot_model:
+            return False, 0.0
+        pipeline = self._get_zero_shot_pipeline()
+        if pipeline is None:
+            return False, 0.0
+        labels = list(self._zero_shot_labels)
+        result = pipeline(text, candidate_labels=labels, multi_label=False)
+        scores = {label: float(score) for label, score in zip(result["labels"], result["scores"])}
+        positive_label = labels[0]
+        score = scores.get(positive_label, 0.0)
+        return score >= self._zero_shot_threshold, score
+
+    # --- Internal helpers ------------------------------------------------
+
+    def _score(self, text: str, queries: Sequence[str]) -> tuple[str | None, float]:
+        cleaned_text = (text or "").strip()
+        if not cleaned_text or not queries:
+            return None, 0.0
+        text_vector = self.encode(cleaned_text)
+        if not np.any(text_vector):
+            return None, 0.0
+        best_query: str | None = None
+        best_score = -1.0
+        for query in queries:
+            vector = self._query_cache.get(query)
+            if vector is None:
+                vector = self.encode(query)
+                self._query_cache[query] = vector
+            score = float(np.dot(text_vector, vector))
+            if score > best_score:
+                best_score = score
+                best_query = query
+        if best_score < 0.0:
+            return None, 0.0
+        return best_query, best_score
+
+    def _resolve_model_path(self, model_name: str) -> str:
+        if self._models_path:
+            candidate = self._models_path / model_name
+            if candidate.exists():
+                return str(candidate)
+        return model_name
+
+    def _get_or_load_model(self, model_name: str) -> SentenceTransformer:
+        resolved = self._resolve_model_path(model_name)
+        with _MODEL_LOCK:
+            model = _MODEL_CACHE.get(resolved)
+            if model is None:
+                model = self._model_loader(resolved, self._device)
+                _MODEL_CACHE[resolved] = model
+        return model
+
+    @staticmethod
+    def _load_model_default(model_name: str, device: str | None) -> SentenceTransformer:
+        return SentenceTransformer(model_name, device=device)
+
+    def _get_zero_shot_pipeline(self) -> Callable[[str, Sequence[str], bool], dict] | None:
+        if not self._zero_shot_model:
+            return None
+        try:
+            from transformers import pipeline  # type: ignore
+        except ImportError:  # pragma: no cover - optional dependency
+            return None
+        resolved = self._resolve_model_path(self._zero_shot_model)
+        with _MODEL_LOCK:
+            classifier = _ZERO_SHOT_CACHE.get(resolved)
+            if classifier is None:
+                device_index = -1
+                if self._device and self._device not in {"cpu", "auto"}:
+                    device_index = 0
+                classifier = pipeline(
+                    "zero-shot-classification",
+                    model=resolved,
+                    tokenizer=resolved,
+                    device=device_index,
+                )
+                _ZERO_SHOT_CACHE[resolved] = classifier
+        return classifier  # type: ignore[return-value]
+

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+SRC = ROOT / "src"
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))

--- a/tests/monitor/test_detail_service.py
+++ b/tests/monitor/test_detail_service.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+from src.db.repo import AppPreferences, Repository
+from src.monitor.detail_service import DetailScanService
+
+
+class DummyProvider:
+    def __init__(self, text: str) -> None:
+        self._text = text
+
+    async def fetch_detail_text(self, url: str) -> str:
+        return self._text
+
+
+class FakeSemanticAnalyzer:
+    def __init__(self, query: str, score: float = 0.95) -> None:
+        self.query = query
+        self.score = score
+        self.last: tuple[str | None, float] | None = None
+
+    def is_relevant(self, text: str, queries: list[str], threshold: float) -> tuple[bool, float]:
+        if self.query in queries and "серверного оборудования" in text:
+            self.last = (self.query, self.score)
+            return True, self.score
+        self.last = None
+        return False, 0.0
+
+    def explain_last_match(self, text: str, queries: list[str]) -> tuple[str | None, float] | None:
+        return self.last
+
+
+async def _run_semantic_test() -> None:
+    provider = DummyProvider("поставка серверного оборудования с монтажом")
+    repo = SimpleNamespace(
+        mark_detail_loaded=AsyncMock(),
+        complete_detail_scan=AsyncMock(),
+        has_notification_global_sent=AsyncMock(return_value=False),
+        create_notification_global=AsyncMock(),
+    )
+    bot = AsyncMock()
+    auth_state = SimpleNamespace(authorized_targets=lambda: [12345])
+    analyzer = FakeSemanticAnalyzer("закупка оборудования", score=0.92)
+    config = SimpleNamespace(source_id="test-source", detail=SimpleNamespace(interval_seconds=60))
+    semantic_config = SimpleNamespace(threshold=0.7)
+
+    service = DetailScanService(
+        provider=provider,
+        repository=repo,  # type: ignore[arg-type]
+        bot=bot,
+        provider_config=config,  # type: ignore[arg-type]
+        auth_state=auth_state,  # type: ignore[arg-type]
+        semantic_analyzer=analyzer,  # type: ignore[arg-type]
+        semantic_config=semantic_config,  # type: ignore[arg-type]
+    )
+
+    prefs = AppPreferences(
+        keywords=[],
+        semantic_queries=["закупка оборудования"],
+        interval_seconds=60,
+        pages=1,
+        enabled=True,
+        semantic_threshold=0.5,
+    )
+    item = Repository.PendingDetail(
+        id=1,
+        source_id="test-source",
+        external_id="abc",
+        url="https://example.org",
+        title="Тестовая закупка",
+        retry_count=0,
+        next_retry_at=None,
+    )
+
+    await service._process_item(item, prefs, [], prefs.semantic_queries)
+
+    bot.send_message.assert_awaited_once()
+    message_text = bot.send_message.await_args.kwargs["text"]
+    assert "Семантическое совпадение" in message_text
+    repo.create_notification_global.assert_awaited_once()
+    repo.complete_detail_scan.assert_awaited_with(item.id)
+    repo.mark_detail_loaded.assert_awaited_with(item.id, True)
+
+
+def test_semantic_match_triggers_notification() -> None:
+    asyncio.run(_run_semantic_test())

--- a/tests/semantic/test_analyzer.py
+++ b/tests/semantic/test_analyzer.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from src.semantic import SemanticAnalyzer
+
+
+class DummyModel:
+    def __init__(self, vectors: dict[str, np.ndarray]) -> None:
+        self._vectors = vectors
+        self.calls: list[str] = []
+
+    def encode(self, sentences, **kwargs):  # type: ignore[override]
+        if isinstance(sentences, str):
+            self.calls.append(sentences)
+            return self._vectors.get(sentences, np.zeros(3, dtype=np.float32))
+        outputs = []
+        for sentence in sentences:
+            self.calls.append(sentence)
+            outputs.append(self._vectors.get(sentence, np.zeros(3, dtype=np.float32)))
+        return np.array(outputs)
+
+
+@pytest.fixture()
+def analyzer_and_model() -> tuple[SemanticAnalyzer, DummyModel]:
+    vectors = {
+        "поставка серверного оборудования": np.array([1.0, 0.0, 0.0], dtype=np.float32),
+        "закупка оборудования": np.array([0.9, 0.1, 0.0], dtype=np.float32),
+        "ремонт": np.array([0.0, 1.0, 0.0], dtype=np.float32),
+        "случайный текст": np.array([0.1, 0.9, 0.0], dtype=np.float32),
+    }
+    dummy = DummyModel(vectors)
+    model_name = f"dummy-{id(dummy)}"
+    analyzer = SemanticAnalyzer(
+        model_name,
+        model_loader=lambda name, device=None: dummy,
+    )
+    return analyzer, dummy
+
+
+def test_encode_normalizes(analyzer_and_model: tuple[SemanticAnalyzer, DummyModel]) -> None:
+    analyzer, _ = analyzer_and_model
+    vec = analyzer.encode("поставка серверного оборудования")
+    assert pytest.approx(np.linalg.norm(vec), rel=1e-6) == 1.0
+
+
+def test_is_relevant_matches_best_query(analyzer_and_model: tuple[SemanticAnalyzer, DummyModel]) -> None:
+    analyzer, _ = analyzer_and_model
+    text = "поставка серверного оборудования"
+    queries = ["закупка оборудования", "ремонт"]
+    relevant, score = analyzer.is_relevant(text, queries, 0.5)
+    assert relevant is True
+    assert score > 0.9
+    query, detail_score = analyzer.explain_last_match(text, queries) or (None, None)
+    assert query == "закупка оборудования"
+    assert detail_score is not None and detail_score == pytest.approx(score)
+
+
+def test_query_embeddings_cached(analyzer_and_model: tuple[SemanticAnalyzer, DummyModel]) -> None:
+    analyzer, dummy = analyzer_and_model
+    text = "поставка серверного оборудования"
+    query = ["закупка оборудования"]
+    analyzer.is_relevant(text, query, 0.5)
+    analyzer.is_relevant(text, query, 0.5)
+    assert dummy.calls.count("закупка оборудования") == 1
+    assert dummy.calls.count(text) == 2


### PR DESCRIPTION
## Summary
- add a semantic analyzer that loads local embedding models and exposes cosine-similarity helpers for tender texts
- extend configuration, data model, and bot handlers with semantic queries, thresholds, and management commands
- integrate semantic checks into the detail scanner, add download script, documentation updates, and regression/unit tests

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68ea1bb8e2d883239fdab320d2916bf2