### PR TITLE
Reduce Docker build dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,10 +6,6 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 WORKDIR /app
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    build-essential \
-    libxml2-dev \
-    libxslt1-dev \
-    libffi-dev \
     tzdata \
     ca-certificates \
  && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Summary
- address docker build failures due to full apt cache when installing heavy build dependencies
- trim the image setup to install only tzdata and ca-certificates so package downloads stay small

## Testing
- not run (docker build command fails in CI before change)

------
https://chatgpt.com/codex/tasks/task_e_68ece8011df88323812753ea8d81dc38