### PR TITLE
Add multi-source provider configuration support

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@
 
    ```
    TELEGRAM_BOT_TOKEN=123456:ABC...
+   SOURCE_IDS=goszakupki.by
+   SOURCE_PREFIX=GZ
    SOURCE_PAGES_DEFAULT=2
    CHECK_INTERVAL_DEFAULT=300
    HTTP_TIMEOUT_SECONDS=10
@@ -31,6 +33,7 @@
    DEEPSEEK_ENABLED=1
    DEEPSEEK_MODEL=deepseek-chat
    DEEPSEEK_MIN_SCORE=0.6
+   GZ_SOURCE_BASE_URL=https://goszakupki.by/tenders/posted
    GZ_LIST_ITEM=.tenders-list .tender-card
    GZ_TITLE=.tender-card__title
    GZ_LINK=.tender-card__title a
@@ -47,13 +50,18 @@
 
 3. При необходимости добавьте другие переменные из `src/config.py`.
    
-   Переменные `GZ_DETAIL_*` управляют выделением «основного контента» на странице закупки для полнотекстового поиска:
-   - `GZ_DETAIL_MAIN` — CSS селектор контейнера основной области (если не задан, используется набор типичных кандидатов).
-   - `GZ_DETAIL_TEXT_SELECTORS` — CSV-список селекторов внутри основного контейнера; если заданы, текст собирается только из них.
-   - `GZ_DETAIL_EXCLUDE` — CSV-список селекторов, которые удаляются перед извлечением текста (меню, хлебные крошки, кнопки).
+   Источники задаются через `SOURCE_IDS` и префиксы окружения:
+   - `SOURCE_IDS=goszakupki.by,icetrade.by`
+   - `SOURCE_PREFIXES=GZ,ICE` (порядок совпадает с `SOURCE_IDS`)
+   - Для каждого источника используйте переменные с префиксом (`GZ_`, `ICE_`), например `GZ_SOURCE_BASE_URL`, `ICE_SOURCE_BASE_URL` и селекторы `*_LIST_ITEM`, `*_TITLE`, `*_LINK`.
+   
+   Переменные `<PREFIX>_DETAIL_*` управляют выделением «основного контента» на странице закупки для полнотекстового поиска:
+   - `<PREFIX>_DETAIL_MAIN` — CSS селектор контейнера основной области (если не задан, используется набор типичных кандидатов).
+   - `<PREFIX>_DETAIL_TEXT_SELECTORS` — CSV-список селекторов внутри основного контейнера; если заданы, текст собирается только из них.
+   - `<PREFIX>_DETAIL_EXCLUDE` — CSV-список селекторов, которые удаляются перед извлечением текста (меню, хлебные крошки, кнопки).
    
    Парсинг списка:
-   - `GZ_PREFER_TABLE` — если 1, использовать табличный разбор раздела заявок (`//*[@id="w0"]/table/tbody/tr`) как основной метод.
+   - `<PREFIX>_PREFER_TABLE` — если 1, использовать табличный разбор раздела заявок (`//*[@id="w0"]/table/tbody/tr`) как основной метод.
    
    Параметры детального сканера:
    - `DETAIL_INTERVAL_SECONDS` — интервал тика детсканера (сканер всегда активен). Обрабатывается по одной записи за тик.

--- a/src/app.py
+++ b/src/app.py
@@ -20,8 +20,9 @@ async def main() -> None:
     configure_logging(config.logging.level)
     container = Container(config)
     await container.init_database()
-    if hasattr(container.provider, "startup"):
-        await getattr(container.provider, "startup")()
+    for provider in container.providers:
+        if hasattr(provider, "startup"):
+            await getattr(provider, "startup")()
 
     # Load persisted authorization state
     await container.auth_state.load()

--- a/src/monitor/detail_scheduler.py
+++ b/src/monitor/detail_scheduler.py
@@ -19,12 +19,12 @@ class DetailScanScheduler:
         *,
         service: DetailScanService,
         repository: Repository,
-        provider_config: ProviderConfig,
+        provider_configs: list[ProviderConfig],
         logging_config: LoggingConfig,
     ) -> None:
         self._service = service
         self._repo = repository
-        self._provider_config = provider_config
+        self._provider_configs = provider_configs
         self._scheduler = AsyncIOScheduler(timezone=logging_config.timezone)
         self._job = None
 
@@ -54,4 +54,7 @@ class DetailScanScheduler:
 
     async def _determine_interval(self) -> int:
         # Жёстко используем значение из конфигурации, минимум 1 сек.
-        return max(self._provider_config.detail.interval_seconds, 1)
+        if not self._provider_configs:
+            return 1
+        interval = min(cfg.detail.interval_seconds for cfg in self._provider_configs)
+        return max(interval, 1)

--- a/src/monitor/scheduler.py
+++ b/src/monitor/scheduler.py
@@ -19,12 +19,12 @@ class MonitorScheduler:
         *,
         service: MonitorService,
         repository: Repository,
-        provider_config: ProviderConfig,
+        provider_configs: list[ProviderConfig],
         logging_config: LoggingConfig,
     ) -> None:
         self._service = service
         self._repo = repository
-        self._provider_config = provider_config
+        self._provider_configs = provider_configs
         self._scheduler = AsyncIOScheduler(timezone=logging_config.timezone)
         self._job = None
 
@@ -62,4 +62,7 @@ class MonitorScheduler:
         prefs = await self._repo.get_preferences()
         if prefs and prefs.interval_seconds > 0:
             return prefs.interval_seconds
-        return max(self._provider_config.check_interval_default, 60)
+        if not self._provider_configs:
+            return 60
+        interval = min(cfg.check_interval_default for cfg in self._provider_configs)
+        return max(interval, 60)


### PR DESCRIPTION
### Motivation
- Поддержать несколько источников закупок с независимыми селекторами/URL, чтобы можно было мониторить `goszakupki.by`, `icetrade.by` и др. одновременно. 
- Разграничить переменные окружения для каждого источника через префиксы (`GZ_`, `ICE_` и т.д.) и `SOURCE_IDS`, чтобы конфигурации не мешали друг другу. 
- Передать список провайдеров в DI/монитор/детсканер и использовать `ProviderConfig.source_id` для корректной дедупликации уведомлений без изменений в схеме БД. 

### Description
- Добавлен список провайдеров в `AppConfig` (`providers: list[ProviderConfig]`) и свойство-совместимость `provider` которое возвращает первый элемент для обратной совместимости. 
- Реализована загрузка конфигураций из ENV: `SOURCE_IDS`, `SOURCE_PREFIXES` / `SOURCE_PREFIX` и префиксные переменные вида `<PREFIX>_SOURCE_BASE_URL`, `<PREFIX>_LIST_ITEM`, `<PREFIX>_TITLE`, `<PREFIX>_LINK`, `<PREFIX>_DETAIL_*` через новые функции `load_config` + вспомогательные `_split_csv`, `_resolve_source_prefixes`, `_get_prefixed*`, `_load_provider_config` в `src/config.py`. 
- DI обновлён: `Container` создаёт `self.providers` (по одному `GoszakupkiHttpProvider` на `ProviderConfig`), и прокидывает `ProviderEntry` (пара `provider`+`config`) в `MonitorService` и `DetailScanService`; при shutdown/startup теперь вызываются соответствующие методы для всех провайдеров (`src/di.py`, `src/app.py`). 
- Монитор и детсканер переработаны на мульти‑провайдерную работу: `MonitorService` итерирует по провайдерам и записывает detections с `source_id` из `ProviderConfig`, `DetailScanService` выбирает провайдера по `item.source_id` и использует его для загрузки детального текста и отправки уведомлений; планировщики (`MonitorScheduler`, `DetailScanScheduler`) вычисляют интервалы на основе минимальных значений среди провайдеров (`src/monitor/*.py`). 
- Документация обновлена (`README.md`) с описанием `SOURCE_IDS`/`SOURCE_PREFIXES` и примерами префиксных переменных. 
- Изменён набор файлов: `src/config.py`, `src/di.py`, `src/app.py`, `src/monitor/service.py`, `src/monitor/detail_service.py`, `src/monitor/scheduler.py`, `src/monitor/detail_scheduler.py`, `README.md`.

### Testing
- Автоматические тесты не запускались в этом изменении. 
- Код базово собран/подвергался ручной проверке путём запуска локальных скриптов редактирования и коммитов, но `pytest`/типизация/интеграционные проверки не выполнялись.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69826be88b108323a8f0df99b1b66af5)